### PR TITLE
Fix delete when a post has no images

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,20 +200,23 @@
 
                     var regex = new RegExp(url.replace(/\./g, "\\.") + '([\\w-]||/)+\\.[\\w]+', 'g');
                     var path = content.match(regex);
-                    var files = path.map(function (a) { return { "Key": a.replace(url, "") }; });
-
-                    s3bucket.deleteObjects({
-                        Bucket: constants.config.env.bucket || constants.config.db.bucket,
-                        Delete: {
-                            Objects: files
-                        }
-                    }, function (err, data) {
-                        if (err) {
-                            log('error', err);
-                        }
-
-                        log('info', data);
-                    })
+                    
+                    if (path) {
+                        var files = path.map(function (a) { return { "Key": a.replace(url, "") }; });
+    
+                        s3bucket.deleteObjects({
+                            Bucket: constants.config.env.bucket || constants.config.db.bucket,
+                            Delete: {
+                                Objects: files
+                            }
+                        }, function (err, data) {
+                            if (err) {
+                                log('error', err);
+                            }
+    
+                            log('info', data);
+                        });
+                    }
                 }
             });
         },


### PR DESCRIPTION
If a post has no images (a worker of) NodeBB will crash with:

```
22/3 09:17 [2015] - error: TypeError: Cannot call method 'map' of null
    at /data/nettle-server/550cdb1be1e933cedae8b543/55016a31642bde40073426fe_qanda_1427029576371/0.6.1/node_modules/nodebb-plugin-amazons3/index.js:203:38
    at /data/nettle-server/550cdb1be1e933cedae8b543/55016a31642bde40073426fe_qanda_1427029576371/0.6.1/src/posts.js:122:4
    at /data/nettle-server/550cdb1be1e933cedae8b543/55016a31642bde40073426fe_qanda_1427029576371/0.6.1/src/posts.js:135:5
    at Object.Plugins.fireHook (/data/nettle-server/550cdb1be1e933cedae8b543/55016a31642bde40073426fe_qanda_1427029576371/0.6.1/src/plugins/hooks.js:60:11)
    at /data/nettle-server/550cdb1be1e933cedae8b543/55016a31642bde40073426fe_qanda_1427029576371/0.6.1/src/posts.js:134:12
    at /data/nettle-server/550cdb1be1e933cedae8b543/55016a31642bde40073426fe_qanda_1427029576371/0.6.1/src/database/redis/hash.js:37:4
    at /data/nettle-server/550cdb1be1e933cedae8b543/55016a31642bde40073426fe_qanda_1427029576371/0.6.1/src/database/redis/hash.js:66:4
    at /data/nettle-server/550cdb1be1e933cedae8b543/55016a31642bde40073426fe_qanda_1427029576371/0.6.1/node_modules/redis/index.js:1138:13
    at try_callback (/data/nettle-server/550cdb1be1e933cedae8b543/55016a31642bde40073426fe_qanda_1427029576371/0.6.1/node_modules/redis/index.js:573:9)
    at RedisClient.return_reply (/data/nettle-server/550cdb1be1e933cedae8b543/55016a31642bde40073426fe_qanda_1427029576371/0.6.1/node_modules/redis/index.js:661:13)
```